### PR TITLE
Fix superfluos <BR> in table data

### DIFF
--- a/src/view/chapter.rb
+++ b/src/view/chapter.rb
@@ -25,7 +25,7 @@ module ODDB
         if paragraph.is_a? String
           return context.span({ 'style' => self.class::PAR_STYLE }) { paragraph }
         end
-        txt = u paragraph.text
+        txt = paragraph.text.encode("UTF-8")
         paragraph.formats.each { |format|
           tag = :span
           style = [] 
@@ -60,7 +60,7 @@ module ODDB
         }
         if(paragraph.preformatted?)
           context.pre({ 'style' => self.class::PRE_STYLE }) { res }
-        else
+        elsif not paragraph.to_s.eql?('')
           ## this must be an inline element, to enable starting 
           ## paragraphs on the same line as the section-subheading
           context.span({ 'style' => self.class::PAR_STYLE }) { 
@@ -72,7 +72,6 @@ module ODDB
               res.gsub("\n", br) 
             end
           } << context.br.force_encoding('utf-8')
-
         end
       end
       def heading(context)


### PR DESCRIPTION
Looks good after reeimport. Comparing the text copied from the browser shows that oddb.ch now has a lot less line breaks in it compard to swissmedicinfo. E.g 

Arzneimittel in Ko-administration   Dosis/ Verabreichungs-schema des ko-administrierten Arzneimittels Dosis/ Verabreichungs-schema von Raltegravir  Verhältnis (90%-Konfidenzintervall) der pharmakokinetischen Parameter von Raltegravir mit/ohne Koadministration eines anderen Arzneimittels; kein Einfluss = 1,00
n Cmax  AUC Cmin
Atazanavir  400 mg täglich  100 mg Einzeldosis  10  1,53 (1,11; 2,12) 1,72 (1,47; 2,02) 1,95 (1,30; 2,92)
Atazanavir/Ritonavir  300 mg/100 mg täglich 400 mg zweimal täglich  10  1,24 (0,87; 1,77) 1,41 (1,12; 1,78) 1,77 (1,39; 2,25)
Darunavir/Ritonavir 600 mg/100 mg zweimal täglich 400 mg zweimal täglich  6 0,67 (0,33-1,37)  0,71 (0,38-1,33)  1,38 (0,16-12,12)
Efavirenz 600 mg täglich  400 mg Einzeldosis  9 0,64 (0,41; 0,98)   0,64 (0,52; 0,80)   0,79 (0,49; 1,28)
Etravirin 200 mg zweimal täglich  400 mg zweimal täglich  19  0,89 (0,68, 1,15)   0,90 (0,68, 1,18)   0,66 (0,34, 1,26)
Omeprazole  20 mg täglich 400 mg Einzeldosis  14 (10 für AUC)   4,15 (2,82, 6,10)   3,12 (2,13, 4,56)   1,46 (1,10, 1,93)
Rifampicin  600 mg täglich  400 mg Einzeldosis  9 0,62 (0,37; 1,04)   0,60 (0,39; 0,91)   0,39 (0,30; 0,51)
Rifampicin  600 mg täglich  800 mg zweimal täglich  14  1,62\* (1,12, 2,33)  1,27\* (0,94, 1,71)  0,47\* (0,36, 0,61)
Ritonavir 100 mg zweimal täglich  400 mg Einzeldosis  10  0,76 (0,55; 1,04)   0,84 (0,70; 1,01) 0,99 (0,70; 1,40)
Tenofovir 300 mg täglich  400 mg zweimal täglich  9 1,64 (1,16; 2,32)   1,49 (1,15; 1,94)   1,03 (0,73; 1,45)
Tipranavir/Ritonavir  500 mg/200 mg zweimal täglich 400 mg zweimal täglich  15 (14 für Cmin)  0,82 (0,46; 1,46) 0,76 (0,49; 1,19) 0,45 (0,31; 0,66)

Is spread over many, many lines on swissmedicinfo. But I think ours is more readable!
