### PR TITLE
Fixed nil pointer when @nonconforming_content is empty

### DIFF
--- a/src/plugin/text_info.rb
+++ b/src/plugin/text_info.rb
@@ -222,7 +222,7 @@ module ODDB
     end
     def report
       unknown_size = @unknown_iksnrs.size
-      @nonconforming_content.uniq!.sort! if @nonconforming_content and @nonconforming_content.size > 0
+      @nonconforming_content = @nonconforming_content.uniq.sort
       unknown = @unknown_iksnrs.collect { |iksnr, name|
         "#{name} (#{iksnr})"
       }.join("\n")


### PR DESCRIPTION
Ruby surprised me!
