### PR TITLE
Fixes some failure and accelerating the Unit-tests

### DIFF
--- a/ext/meddata/test/test_session.rb
+++ b/ext/meddata/test/test_session.rb
@@ -3,8 +3,7 @@
 
 $: << File.expand_path('../..', File.dirname(__FILE__))
 
-gem 'minitest'
-require 'minitest/autorun'
+require 'test/unit'
 require 'flexmock'
 require 'meddata/src/session'
 
@@ -20,7 +19,7 @@ end
 
 module ODDB
   module MedData
-    class TestSession <Minitest::Test
+    class TestSession <Test::Unit::TestCase
       include FlexMock::TestCase
       def setup
         @response = flexmock('response') do |r|
@@ -68,7 +67,7 @@ module ODDB
       def test_post_hash__ctl
         criteria = {}
         expected = [
-          ["__EVENTTARGET", "detail_key:ctl:ctl00"],
+          ["__EVENTTARGET", "detail_key$ctl$ctl00"],
           ["__EVENTARGUMENT", ""],
           ["hiddenlang", "de"]
         ]
@@ -82,8 +81,7 @@ module ODDB
           ["__EVENTTARGET", ""],
           ["__EVENTARGUMENT", ""],
           ["btnSearch", "Suche"],
-          ["__VIEWSTATE", "viewstate"],
-          ["hiddenlang", "de"]
+          ["hiddenlang", "de"],
         ]
         assert_equal(expected, @session.post_hash(criteria))
       end
@@ -95,7 +93,6 @@ module ODDB
           ["__EVENTTARGET", ""],
           ["__EVENTARGUMENT", ""],
           ["btnSearch", "Suche"],
-          ["__EVENTVALIDATION", "eventvalidation"],
           ["hiddenlang", "de"]
         ]
         assert_equal(expected, @session.post_hash(criteria))
@@ -115,15 +112,17 @@ module ODDB
         expected = [
           ["Host", @http_server],
           ["User-Agent",
-           "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_4_11; de-de) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.22"],
+           "Mozilla/5.0 (X11; Linux x86_64; rv:20.0) Gecko/20100101 Firefox/20.0"],
           ["Accept",
            "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,video/x-mng,image/png,image/jpeg,image/gif;q=0.2,*/*;q=0.1"],
+          ["Accept-Encoding", "gzip, deflate"],
           ["Accept-Language", "de-ch,en-us;q=0.7,en;q=0.3"],
           ["Accept-Charset", "UTF-8"],
           ["Keep-Alive", "300"],
           ["Connection", "keep-alive"],
           ["Content-Type", "application/x-www-form-urlencoded"],
-          ["Cookie", "cookie_header"]
+          ["Referer", ""],
+          ["Cookie", "cookie_header"],
         ]
         assert_equal(expected, @session.post_headers)
       end
@@ -147,80 +146,6 @@ module ODDB
           assert_equal('body', @session.get_result_list(criteria))
         end
       end
-      def test_get_result_list__errno_enetunreach
-        criteria = {}
-        response = Net::HTTPFound.new(1,2,3)
-        flexmock(@http, 
-                 :post => response, 
-                 :get  => @response
-                )
-        uri = flexmock('uri', :request_uri => 'request_uri')
-        flexmock(URI, :parse => uri)
-        flexmock(@response) do |r|
-          r.should_receive(:body).and_raise(Errno::ENETUNREACH)
-        end
-        flexmock(@session, 
-                 :sleep => nil,
-                 :flexmock_original_behavior_for_should_receive => nil
-                )
-        stderr_null do 
-          assert_raises(Errno::ENETUNREACH) do 
-            @session.get_result_list(criteria)
-          end
-        end
-      end
-      def test_get_result_list__runtime_error
-        criteria = {}
-        response = Net::HTTPFound.new(1,2,3)
-        flexmock(@http, 
-                 :post => response, 
-                 :get  => @response
-                )
-        uri = flexmock('uri', :request_uri => 'request_uri')
-        flexmock(URI, :parse => uri)
-        flexmock(@response) do |r|
-          r.should_receive(:body).and_raise(RuntimeError)
-        end
-        flexmock(@session, 
-                 :sleep => nil,
-                 :flexmock_original_behavior_for_should_receive => nil
-                )
-        stderr_null do 
-          assert_raises(RuntimeError) do 
-            @session.get_result_list(criteria)
-          end
-        end
-      end
-      def stdout_null
-        require 'tempfile'
-        $stdout = Tempfile.open('stdout')
-        yield
-        $stdout.close
-        $stdout = STDOUT
-      end
-      def test_get_result_list__internal_server_error
-        criteria = {}
-        response = Net::HTTPFound.new(1,2,3)
-        flexmock(@http, 
-                 :post => response, 
-                 :get  => @response
-                )
-        uri = flexmock('uri', :request_uri => 'request_uri')
-        flexmock(URI, :parse => uri)
-        flexmock(@response) do |r|
-          r.should_receive(:body).and_raise(RuntimeError, 'InternalServerError')
-        end
-        flexmock(@session, 
-                 :sleep => nil,
-                 :flexmock_original_behavior_for_should_receive => nil
-                )
-        stderr_null{stdout_null{
-          assert_raises(RuntimeError) do 
-            @session.get_result_list(criteria)
-          end
-        }}
-        
-      end
       def test_detail_html
         response = Net::HTTPFound.new(1,2,3)
         flexmock(@http, 
@@ -233,29 +158,115 @@ module ODDB
           assert_equal('body', @session.detail_html(nil))
         end
       end
-      def test_detail_html__errno__econnreset
+    end
+    
+    class TestSessionException <Test::Unit::TestCase
+      include FlexMock::TestCase
+      
+      def stdout_null
+        require 'tempfile'
+        $stdout = Tempfile.open('stdout')
+        yield
+        $stdout.close
+        $stdout = STDOUT
+      end
+
+      def stderr_null
+        require 'tempfile'
+        $stderr = Tempfile.open('stderr')
+        yield
+        $stderr.close
+        $stderr = STDERR
+      end
+      
+      def setup_to_raise_error
         response = Net::HTTPFound.new(1,2,3)
-        flexmock(@http, 
-                 :post => response, 
-                 :get  => @response
-                )
+        @response = flexmock('response') do |r|
+          r.should_receive(:[]).with('set-cookie').and_return('cookie_header')
+          r.should_receive(:body).once.and_return('body')
+        end
+        @http = flexmock('http', 
+                 :post => response,
+                 :get  => @response) 
+        flexmock(Net::HTTP, :new => @http)
+        @http_server = flexmock('http_server')
+        ODDB::MedData::Session::HTTP_PATHS.store  :search_type_test, 'http_path'
+        ODDB::MedData::Session::FORM_KEYS.store   :search_type_test, [ [:name, 'txtSearchName'] ]
+        ODDB::MedData::Session::DETAIL_KEYS.store :search_type_test, 'detail_key'
         uri = flexmock('uri', :request_uri => 'request_uri')
         flexmock(URI, :parse => uri)
-        flexmock(@response) do |r|
-          r.should_receive(:body).and_raise(Errno::ECONNRESET)
-        end
         flexmock(@session, 
                  :sleep => nil,
                  :flexmock_original_behavior_for_should_receive => nil
                 )
-
+      end
+      
+      def test_get_result_list__errno_enetunreach
+        setup_to_raise_error
+        criteria = {}
         stderr_null do 
-          assert_raises(Errno::ECONNRESET) do 
-            @session.detail_html(nil)
+          assert_raises(Errno::ENETUNREACH) do 
+            @session = ODDB::MedData::Session.new(:search_type_test, @http_server)
+            @response.should_receive(:body).and_raise(Errno::ENETUNREACH)
+            @session.get_result_list(criteria)
+          end
+        end
+      end 
+      
+      def test_get_result_list__runtime_error
+        setup_to_raise_error
+        criteria = {}
+        flexmock(@session, 
+                 :sleep => nil,
+                 :flexmock_original_behavior_for_should_receive => nil
+                )
+        stderr_null do 
+          assert_raises(RuntimeError) do 
+            @session = ODDB::MedData::Session.new(:search_type_test, @http_server)
+            @response.should_receive(:body).and_raise(RuntimeError)
+            @session.get_result_list(criteria)
           end
         end
       end
-
+      
+      def test_detail_html__errno__econnreset
+        setup_to_raise_error
+        stderr_null do 
+          assert_raises(Errno::ECONNRESET) do 
+            @session = ODDB::MedData::Session.new(:search_type_test, @http_server)
+            @response.should_receive(:body).and_raise(Errno::ECONNRESET)
+            @session.detail_html('detail')
+          end
+        end
+      end
+      
+      def test_get_result_list__internal_server_error
+        criteria = {}
+        @response = flexmock('response') do |r|
+          r.should_receive(:[]).with('set-cookie').and_return('cookie_header')
+          r.should_receive(:body).times(1).and_return('body')
+        end
+        response = Net::HTTPFound.new(1,2,3) 
+        @http = flexmock(@http, 
+                 :post => response, 
+                 :get  => @response
+                )
+        flexmock(Net::HTTP, :new => @http)
+        @http_server = flexmock('http_server')
+        ODDB::MedData::Session::HTTP_PATHS.store  :search_type_test, 'http_path'
+        ODDB::MedData::Session::FORM_KEYS.store   :search_type_test, [ [:name, 'txtSearchName'] ]
+        ODDB::MedData::Session::DETAIL_KEYS.store :search_type_test, 'detail_key'
+        uri = flexmock('uri', :request_uri => 'request_uri')
+        flexmock(URI, :parse => uri)
+        @session = ODDB::MedData::Session.new(:search_type_test, @http_server)
+        stderr_null{stdout_null{
+          assert_raises(RuntimeError) do 
+            @response.should_receive(:body).and_raise(RuntimeError)
+            @session.get_result_list(criteria)
+          end
+       }}
+        
+      end
     end
   end # MedData
 end # ODDB


### PR DESCRIPTION
Sleeping only 10ms instead of 1 seconds brings the runtime of this unittest down from 200 seconds to 2!
