### PR TITLE
Avoid nil access

### DIFF
--- a/src/view/additional_information.rb
+++ b/src/view/additional_information.rb
@@ -394,6 +394,7 @@ module ODDB
             old_link_format = {'pointer' => patinfo.pointer}
             href = @lookandfeel._event_url(:resolve, old_link_format)
           end
+          return nil unless model and klass
           link = klass.new(:square_patinfo, model, @session, self)
           link.href = href
           link.set_attribute('title', @lookandfeel.lookup(:patinfo))


### PR DESCRIPTION
Fix the "undefined method `new' for nil:NilClass" when looking for price comparision of Amavita Cetirizin

This is however an unusual situation as the error surfaces only because the product "Cetirizin Q-generics" which appears in the list does neither have an FI nor a PI.
