### PR TITLE
Fix log log location. Return false  if no update

### DIFF
--- a/src/plugin/swissmedic.rb
+++ b/src/plugin/swissmedic.rb
@@ -41,7 +41,7 @@ module ODDB
     def debug_msg(msg)
       # $stdout.puts Time.now.to_s + ': ' + msg; $stdout.flush
       if not defined?(@checkLog) or not @checkLog
-        name = LogFile.filename(File.basename(__FILE__), Time.now)
+        name = LogFile.filename('oddb/debug/'+File.basename(__FILE__), Time.now)
         FileUtils.makedirs(File.dirname(name))
         @checkLog = File.open(name, 'a+') 
         $stdout.puts "Opened #{name}"
@@ -92,7 +92,8 @@ module ODDB
           memo
         }
       else
-        debug_msg "#{__FILE__}: #{__LINE__} update skipped as target is #{target.inspect}"
+        debug_msg "#{__FILE__}: #{__LINE__} update return false as target is #{target.inspect}"
+        false
       end
     end
     # check diff from overwritten stored-objects by admin
@@ -262,7 +263,7 @@ module ODDB
         target
       else
         debug_msg "#{__FILE__}: #{__LINE__} skip writing #{target} as #{latest_name} is #{File.size(latest_name)} bytes. Returning latest"
-        latest_name
+        nil
       end
     end
     def initialize_export_registrations(agent)


### PR DESCRIPTION
Lieber Zeno

Jetzt wird false zurück gegeben, wenn es keinen Update gab.

Die Packungen-2014-01-23.xlsx wurde beim Lauf von heute morgen nicht gelöscht, da es einen Fehler gab und sie erst dann gelöscht wird, wenn der update fehlerfrei lief. (src/plugin/swissmedic.rb Zeile 84)

Liebe Grüsse

Niklaus
