### PR TITLE
Avoid NoMethodError for active agents

### DIFF
--- a/src/model/composition.rb
+++ b/src/model/composition.rb
@@ -38,14 +38,16 @@ module ODDB
       odba_store
     end
     def active_agents # aka Wirkstoffe
-
-      @active_agents
+      @active_agents || []
+    end
+    def inactive_agents
+      @inactive_agents || []
     end
     def active_agent(substance_or_oid)
-      @active_agents.find { |active| active.same_as?(substance_or_oid) }
+      active_agents.find { |active| active.same_as?(substance_or_oid) }
     end
     def inactive_agent(substance_or_oid)
-      @inactive_agents.find { |active| active.same_as?(substance_or_oid) }
+      inactive_agents.find { |active| active.same_as?(substance_or_oid) }
     end
     def checkout
       self.galenic_form = nil
@@ -56,7 +58,7 @@ module ODDB
       @active_agents.odba_delete
     end
     def create_active_agent(substance_name)
-      active = @active_agents.find { |active| active.same_as?(substance_name) }
+      active = active_agent(substance_name)
       return active unless active == nil
       active = ActiveAgent.new(substance_name)
       composition = self
@@ -67,7 +69,7 @@ module ODDB
       active
     end
     def delete_active_agent(substance_or_oid)
-      active = @active_agents.find { |active| active.same_as?(substance_or_oid)}
+      active = active_agent(substance_or_oid)
       if(active)
         @active_agents.delete(active)
         @active_agents.odba_isolated_store
@@ -75,7 +77,7 @@ module ODDB
       end
     end
     def create_inactive_agent(substance_name)
-      active = @inactive_agents.find { |active| active.same_as?(substance_name) }
+      active = inactive_agent(substance_name)
       return active unless active == nil
       active = InactiveAgent.new(substance_name)
       composition = self
@@ -86,7 +88,7 @@ module ODDB
       active
     end
     def delete_inactive_agent(substance_or_oid)
-      active = @inactive_agents.find { |active| active.same_as?(substance_or_oid)}
+      active = inactive_agent(substance_or_oid)
       if(active)
         @inactive_agents.delete(active)
         @inactive_agents.odba_isolated_store

--- a/test/test_model/composition.rb
+++ b/test/test_model/composition.rb
@@ -44,6 +44,14 @@ module ODDB
       result = @composition.active_agent('substance')
       assert_kind_of(ODDB::ActiveAgent, @composition.active_agent('substance'))
     end
+    def test_active_agent__does_not_raise_no_method_error
+      @composition.instance_eval('@active_agents = nil')
+      assert_nil(@composition.active_agent('substance_or_oid'))
+    end
+    def test_inactive_agent__does_not_raise_no_method_error
+      @composition.instance_eval('@inactive_agents = nil')
+      assert_nil(@composition.inactive_agent('substance_or_oid'))
+    end
     def test_checkout
       agent  = flexmock('agent',
                                :checkout    => 'checkout',


### PR DESCRIPTION
## Error

```
Plugin: ODDB::SwissmedicPlugin
Error: NoMethodError
Message: undefined method `find' for nil:NilClass
Backtrace:
/var/www/oddb.org/src/model/composition.rb:48:in `inactive_agent'
/usr/local/lib/ruby/gems/1.9.1/gems/odba-1.1.0/lib/odba/stub.rb:112:in
`method_missing'
/var/www/oddb.org/src/plugin/swissmedic.rb:623:in `update_active_agent'
/var/www/oddb.org/src/plugin/swissmedic.rb:769:in `block (2 levels) in
update_compositions'
/var/www/oddb.org/src/plugin/swissmedic.rb:746:in `each'
/var/www/oddb.org/src/plugin/swissmedic.rb:746:in `each_with_index'
/var/www/oddb.org/src/plugin/swissmedic.rb:746:in `block in update_compositions'
/var/www/oddb.org/src/plugin/swissmedic.rb:739:in `each'
/var/www/oddb.org/src/plugin/swissmedic.rb:739:in `each_with_index'
/var/www/oddb.org/src/plugin/swissmedic.rb:739:in `update_compositions'
/var/www/oddb.org/src/plugin/swissmedic.rb:1049:in `update_all_sequence_info'
/var/www/oddb.org/src/plugin/swissmedic.rb:1073:in `block in
update_registrations'
/var/www/oddb.org/src/plugin/swissmedic.rb:1060:in `each'
/var/www/oddb.org/src/plugin/swissmedic.rb:1060:in `update_registrations'
/var/www/oddb.org/src/plugin/swissmedic.rb:167:in `update'
/var/www/oddb.org/src/util/updater.rb:444:in `block in update_swissmedic'
/var/www/oddb.org/src/util/updater.rb:549:in `call'
/var/www/oddb.org/src/util/updater.rb:549:in `wrap_update'
/var/www/oddb.org/src/util/updater.rb:442:in `update_swissmedic'
/var/www/oddb.org/src/util/updater.rb:201:in `run'
jobs/import_daily:13:in `block in <module:Util>'
/var/www/oddb.org/src/util/job.rb:40:in `call'
/var/www/oddb.org/src/util/job.rb:40:in `run'
jobs/import_daily:12:in `<module:Util>'
jobs/import_daily:11:in `<module:ODDB>'
jobs/import_daily:10:in `<main>'
```

## Grund

Ich denke, dass das Error aus einer neue komische Daten (Composition) kommt. Das Composition sieht etwas komisch aus.
Der Import_daily Job kann nicht inactive agent von diesem Composition bei parsed Substance Name aus Swissmedic finden.

## Eine Lösung

Das Composition hat schon ein Method das Problem zu reparieren. Das ist `cleanup_old_active_agent`.
https://github.com/zdavatz/oddb.org/blob/master/src/model/composition.rb#L153

Aber, Wie Niklaus hat so in Wiki gesagt,
Das Method speichert jetzt nicht selbst in Datenbank nach dem Reparieren.
So, das `cleanup_old_active_agent` braucht  wohl `odba_store` danach.

* http://dev.ywesee.com/Niklaus/20150826-fix-active-agents#fix-active-agents
* http://dev.ywesee.com/Niklaus/20150831-sort-active-agents#sort-active-agents

Bitte fragen Sie ihn über das. Wahrscheinlich, er kennt dieses Problem.
Und denke ich, dass wir diese Daten via bin/admin reparieren können.

\# vielleicht
```
# find komisch Composition
ch.oddb> packages.find { |pack| pack.compositions.find { |comp| comp.inactive_agents.nil? } }
->
# reparieren mit cleanup_old_active_agent und fix_pointer (odba_store)
ch.oddb> packages.map {|pack| pack.compositions.map {|comp| unless comp.cleaned; comp.cleanup_old_active_agent; comp.fix_pointers; end } }
```


## Pull Request

Meine kleine Pull-Request vorbeugt diesem Error.
Für alle `find` in Composition, Ich habe getter Method gemacht.

Bei Diese Änderung, Swissmedic Import Job macht das als neues Inactive Agent am here:
https://github.com/zdavatz/oddb.org/blob/master/src/plugin/swissmedic.rb#L626
\# Aber, Ich bin leider nicht sicher, weil ich keine jetzige Daten habe.


Letztlich müssen wir bestätigen, welche Composition komisch ist, und was Substance Name ist.
\# Das braucht letzte Datenbank.

Ich wünsche, dass das nützlich sein. :wink: