### PR TITLE
Update scrolliris domains and paths

### DIFF
--- a/src/view/drugs/fachinfo.rb
+++ b/src/view/drugs/fachinfo.rb
@@ -220,6 +220,7 @@ class FiChapterChooser < HtmlGrid::Composite
     end
   end
   def heatmap(model, session)
+    # text readability heatmap (scrolliris)
     link = HtmlGrid::Link.new(:heatmap, model, session, self)
     link.set_attribute('title', @lookandfeel.lookup(:heatmap))
     link.href = @lookandfeel._event_url(:show,  [:fachinfo, model.registrations.first.iksnr])
@@ -237,7 +238,7 @@ class FiChapterChooser < HtmlGrid::Composite
         , apiKey: '#{ODDB.config.scrolliris_fi_read_key}'
         }
       , settings = {
-          endpointURL: 'https://api.scrolliris.io/v1.0/projects/'+config.projectId+'/results/read?api_key='+config.apiKey
+          endpointURL: 'https://api.scrolliris.com/v1.0/projects/'+config.projectId+'/results/read?api_key='+config.apiKey
         }
       , options = {
           selectors: {
@@ -249,7 +250,7 @@ class FiChapterChooser < HtmlGrid::Composite
           }
         }
       ;
-      var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://widget.scrolliris.io/projects/'+c.projectId+'/reflector.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityReflector,t=(new r.Widget(c,{settings:settings,options:options}));t.render();}catch(_){}};s.parentNode.insertBefore(k,s);
+      var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://lib.scrolliris.com/widget/v1.0/vprojects/'+c.projectId+'/heatmap.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityReflector,t=(new r.Widget(c,{settings:settings,options:options}));t.render();}catch(_){}};s.parentNode.insertBefore(k,s);
     })(document, window);
   }
 })(event);
@@ -436,7 +437,7 @@ class FachinfoComposite < View::Drugs::FachinfoPreviewComposite
     end
     super
     unless @session.user_input(:chapter)
-      # text readability tracker (scrolliris)
+      # text readability measure (scrolliris)
       @additional_javascripts ||= []
       @additional_javascripts << <<-EOS
 (function(d, w) {
@@ -445,7 +446,7 @@ class FachinfoComposite < View::Drugs::FachinfoPreviewComposite
     , apiKey: '#{ODDB.config.scrolliris_fi_write_key}'
     }
   , settings = {
-      endpointURL: 'https://api.scrolliris.io/v1.0/projects/'+config.projectId+'/events/read'
+      endpointURL: 'https://api.scrolliris.com/v1.0/projects/'+config.projectId+'/events/read'
     }
   , options = {
       selectors: {
@@ -457,7 +458,7 @@ class FachinfoComposite < View::Drugs::FachinfoPreviewComposite
       }
     }
   ;
-  var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://script.scrolliris.io/projects/'+c.projectId+'/tracker.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityTracker,t=(new r.Client(c,settings));t.ready(['body'],function(){t.record(options);});}catch(_){}};s.parentNode.insertBefore(k,s);
+  var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://lib.scrolliris.com/script/v1.0/projects/'+c.projectId+'/measure.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityTracker,t=(new r.Client(c,settings));t.ready(['body'],function(){t.record(options);});}catch(_){}};s.parentNode.insertBefore(k,s);
 })(document, window);
 EOS
     end

--- a/src/view/drugs/patinfo.rb
+++ b/src/view/drugs/patinfo.rb
@@ -144,6 +144,7 @@ class PiChapterChooser < HtmlGrid::Composite
     end
   end
   def heatmap(model, session)
+    # text readability heatmap (scrolliris)
     link = HtmlGrid::Link.new(:heatmap, model, session, self)
     link.set_attribute('title', @lookandfeel.lookup(:heatmap))
     seq = model.sequences.first
@@ -165,7 +166,7 @@ class PiChapterChooser < HtmlGrid::Composite
         , apiKey: '#{ODDB.config.scrolliris_fi_read_key}'
         }
       , settings = {
-          endpointURL: 'https://api.scrolliris.io/v1.0/projects/'+config.projectId+'/results/read?api_key='+config.apiKey
+          endpointURL: 'https://api.scrolliris.com/v1.0/projects/'+config.projectId+'/results/read?api_key='+config.apiKey
         }
       , options = {
           selectors: {
@@ -177,7 +178,7 @@ class PiChapterChooser < HtmlGrid::Composite
           }
         }
       ;
-      var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://widget.scrolliris.io/projects/'+c.projectId+'/reflector.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityReflector,t=(new r.Widget(c,{settings:settings,options:options}));t.render();}catch(_){}};s.parentNode.insertBefore(k,s);
+      var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://lib.scrolliris.com/widget/v1.0/projects/'+c.projectId+'/heatmap.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityReflector,t=(new r.Widget(c,{settings:settings,options:options}));t.render();}catch(_){}};s.parentNode.insertBefore(k,s);
     })(document, window);
   }
 })(event);
@@ -268,7 +269,7 @@ class PatinfoComposite < View::Drugs::PatinfoPreviewComposite
   def init
     super
     unless @session.user_input(:chapter)
-      # text readability tracker (scrolliris)
+      # text readability measure (scrolliris)
       @additional_javascripts ||= []
       @additional_javascripts << <<-EOS
 (function(d, w) {
@@ -277,7 +278,7 @@ class PatinfoComposite < View::Drugs::PatinfoPreviewComposite
     , apiKey: '#{ODDB.config.scrolliris_pi_write_key}'
     }
   , settings = {
-      endpointURL: 'https://api.scrolliris.io/v1.0/projects/'+config.projectId+'/events/read'
+      endpointURL: 'https://api.scrolliris.com/v1.0/projects/'+config.projectId+'/events/read'
     }
   , options = {
       selectors: {
@@ -289,7 +290,7 @@ class PatinfoComposite < View::Drugs::PatinfoPreviewComposite
       }
     }
   ;
-  var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://script.scrolliris.io/projects/'+c.projectId+'/tracker.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityTracker,t=(new r.Client(c,settings));t.ready(['body'],function(){t.record(options);});}catch(_){}};s.parentNode.insertBefore(k,s);
+  var a,c=config,f=false,k=d.createElement('script'),s=d.getElementsByTagName('script')[0];k.src='https://lib.scrolliris.com/script/v1.0/projects/'+c.projectId+'/measure.js?api_key='+c.apiKey;k.async=true;k.onload=k.onreadystatechange=function(){a=this.readyState;if(f||a&&a!='complete'&&a!='loaded')return;f=true;try{var r=w.ScrollirisReadabilityTracker,t=(new r.Client(c,settings));t.ready(['body'],function(){t.record(options);});}catch(_){}};s.parentNode.insertBefore(k,s);
 })(document, window);
 EOS
     end


### PR DESCRIPTION
Hi 😎  @zdavatz 🎅  @ngiger ;)

We've updated our domains and hosts because reducing futile DNS lookup(s) to `scrolliris.io`. About details of the changes, see `NOTE` below from a commit message.

The old `scrolliris.io` is also available for a while. After you deploy & confirm this change on production server, I'll sthutdown it. I hope that it's going well, but if you have any trobules on this, you can just rollback it. \# Please tell me, if you have any problems :)

Our concept page ([try.scrolliris.com](https://try.scrolliris.com/)) is already migrated to point this new version api and scripts on CDN and servers are hosted in this new sub-domains.

P.S.
Now we're working on **Heatmap Overlay** on Scrolliris which are demanded by you. This change is also for new overlay feature.


----

NOTE from a commit message:

```
This changes reduce futile DNS lookup(s) to `scrolliris.io`.
Now, we've migrated all img, api, scripts and widgets to `scrolliris.com`.

Also filenames in JavaScript are updated. This update is needed by heatmap overlay feature which is followed this changes.

* Change api.scrolliris.io to api.scrolliris.com
* Change script.scrolliris.io to lib.scrolliris.com/script
* Change widget.scrolliris.io to lib.scrolliris.com/widget
* Rename reflector.js as heatmap.js
* Rename tracker.js as measure.js
```

Happy Scrolling!