### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'multi_json', '1.0.4'
 gem 'needle', '1.3.0'
 gem 'net-http-digest_auth'#, '1.2'
 gem 'net-http-persistent'# , '2.7'
-gem 'nokogiri'# , '1.6.1'
+gem 'nokogiri', '1.10.4'
 gem 'ox', '2.8.2' # a replacement for nokogir
 gem 'odba',  '>= 1.1.6'
 gem 'oddb2tdat', '1.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitar (0.6.1)
     minitest (5.10.2)
     minitest-should_syntax (1.0.2)
@@ -100,8 +100,8 @@ GEM
     needle (1.3.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (2.9.4)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     ntlm-http (0.1.1)
     odba (1.1.6)
@@ -280,7 +280,7 @@ DEPENDENCIES
   needle (= 1.3.0)
   net-http-digest_auth
   net-http-persistent
-  nokogiri
+  nokogiri (= 1.10.4)
   odba (>= 1.1.6)
   oddb2tdat (= 1.1.2)
   optimist

--- a/spec/smoketest_spec.rb
+++ b/spec/smoketest_spec.rb
@@ -620,6 +620,20 @@ describe "ch.oddb.org" do
     expect(text[0..1000]).to match /Homöopathika für Muskeln und Skelett/i
   end
 
+  it "should display the ATC-Browser, way down to H05AA02" do
+    @browser.link(:name => 'atc_chooser').click
+    text = @browser.text.clone
+    expect(text[0..1000]).to match /\(A\)/
+    expect(text[0..1000]).to match /\(V\)/
+    @browser.link(:text => /.*\(H\)/).click
+    @browser.link(:text => /.*\(H05\)/).click
+    @browser.link(:text => /.*\(H05A\)/).click
+    @browser.link(:text => /.*\(H05AA\)/).click
+    @browser.link(:text => /.*\(H05AA02\)/).click
+    text = @browser.text.clone
+    expect(text[0..1000]).to match /Forsteo/
+  end
+
   after :all do
     @browser.close if @browser
   end

--- a/src/plugin/who.rb
+++ b/src/plugin/who.rb
@@ -69,7 +69,7 @@ module ODDB
         msg = value.repair_needed?
         @repairs << msg if msg
       }
-      # run impot
+      # run import
       while(code = @codes.shift)
         @count += 1
         import_code(agent, code)
@@ -103,8 +103,10 @@ module ODDB
       ]
       }
       new_codes.each{ |atc, details|
-          atc_code = import_atc(atc, details[0], :whocc_new)
-          @codes.push(atc_code)
+          if atc.length > 0
+            atc_code = import_atc(atc, details[0], :whocc_new)
+            @codes.push(atc_code)
+        end
       }
     end
     def import_code(agent, get_code)
@@ -112,7 +114,7 @@ module ODDB
       (page/"//b/a").each do |link|
         if(match = @@query_re.match(link.attributes['href']))
           code = match[1]
-          if(code == get_code)
+          if(code == get_code && code.length > 0)
             atc = import_atc(code, link.inner_text.to_s)
             import_guidelines(atc, link)
           end


### PR DESCRIPTION
Unittests ohne Fehler.

Watir specs laufen zum grössten Teil (es gab schon vorher Fehler) auf oddb-ci2.