### PR TITLE
(#420) Nicer log entries for price changes

### DIFF
--- a/src/plugin/bsv_xml.rb
+++ b/src/plugin/bsv_xml.rb
@@ -354,14 +354,14 @@ module ODDB
             ## don't take the Swissmedic-Category unless it's missing in the DB
             @data.delete :ikscat if @pack.ikscat
             if  @pack.price_exfactory.nil? || !@price_exfactory.amount.to_s.eql?(@pack.price_exfactory.amount.to_s) || !@price_change_code.eql?(@pack.price_exfactory.mutation_code)
-              LogFile.debug "tag_end_set price_exfactory #{@price_exfactory} for @pack.price_exfactor '#{@pack.price_exfactory}' #{@pack.price_exfactory&.mutation_code} now #{@price_change_code}"
+              LogFile.debug "#{@iksnr} #{@ikscd} set price_exfactory #{@pack.price_exfactory} now #{@price_exfactory} #{@pack.price_exfactory&.mutation_code} now #{@price_change_code}"
               @pack.price_exfactory = @price_exfactory
               @pack.price_exfactory.mutation_code = @price_exfactory.mutation_code
               @pack.price_exfactory.valid_from = @price_exfactory.valid_from
               @data.store :price_exfactory, @price_exfactory
             end if @price_exfactory
             if @pack.price_public.nil? || !@price_public.amount.to_s.eql?(@pack.price_public.amount.to_s) || !@price_change_code.eql?(@pack.price_public.mutation_code)
-              LogFile.debug "tag_end price_public #{@price_public} for @pack.price_exfactor '#{@pack.price_public}' #{@pack.price_public&.mutation_code} now #{@price_change_code}"
+              LogFile.debug "#{@iksnr} #{@ikscd} set price_public #{@pack.price_public} now #{@price_public} now #{@pack.price_public&.mutation_code} now #{@price_change_code}"
               @pack.price_public = @price_public
               @pack.price_public.valid_from = @price_public.valid_from
               @pack.price_public.mutation_code = @price_public.mutation_code

--- a/test/test_plugin/bsv_xml.rb
+++ b/test/test_plugin/bsv_xml.rb
@@ -1616,6 +1616,7 @@ module ODDB
       @myPackage.price_exfactory = Util::Money.new(10, @price_type, 'CH')
       @myPackage.price_exfactory.valid_from = Time.new(2022,1,31)
       @myPackage.price_exfactory.origin = originUrl22
+      @myPackage.price_exfactory.mutation_code = '1JAHRS'
       @myPackage.price_exfactory.type = "exfactory"
 
       @myPackage.price_exfactory = Util::Money.new(10, @price_type, 'CH')


### PR DESCRIPTION
Creates entries like this (from the test_nasonex_exfactory_price)

```
2024-02-09 10:44:04 +0000: /opt/path_to_oddb/oddb.org/src/plugin/bsv_xml.rb:357:in `tag_end': 54189 036 set price_exfactory 10.00 now 8.50 1JAHRS now FREIWILLIGEPS
2024-02-09 10:44:04 +0000: /opt/path_to_oddb/oddb.org/src/plugin/bsv_xml.rb:364:in `tag_end': 54189 036 set price_public 18.00 now 18.00 now  now FREIWILLIGEPS

```