### PR TITLE
Ruby 3 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [3.2]
+        ruby: [3.2, 3.3]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,6 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.1)
     builder (3.2.4)
-    chrono_logger (1.1.2)
     clogger (2.3.1)
       rack (>= 1.0, < 3.0)
     cmath (1.0.0)
@@ -33,12 +32,12 @@ GEM
     data_magic (1.2)
       faker (>= 1.1.2)
       yml_reader (>= 0.6)
+    date (3.3.4)
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     deprecated (2.0.1)
     diff-lcs (1.5.0)
-    digest (3.1.1)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -64,7 +63,6 @@ GEM
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    io-wait (0.2.1)
     irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
@@ -88,7 +86,7 @@ GEM
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     mini_portile2 (2.8.5)
     minitar (0.9)
     minitest (5.15.0)
@@ -103,21 +101,15 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    net-imap (0.2.3)
-      digest
+    net-imap (0.4.10)
+      date
       net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
+    net-pop (0.1.2)
       net-protocol
+    net-protocol (0.2.2)
       timeout
-    net-protocol (0.1.2)
-      io-wait
-      timeout
-    net-smtp (0.3.1)
-      digest
+    net-smtp (0.4.0.1)
       net-protocol
-      timeout
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -141,7 +133,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (4.0.7)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -149,7 +141,7 @@ GEM
       rack
       webrick
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rbs (2.0.0)
     rclconf (1.0.0)
     rdoc (6.6.2)
@@ -205,10 +197,9 @@ GEM
       nori (~> 2.4)
       wasabi (~> 3.4)
     sax-machine (1.3.2)
-    sbsm (1.6.1)
-      chrono_logger
+    sbsm (1.6.2)
       hpricot
-      mail
+      mail (< 2.8.0)
       mimemagic
       rack
     selenium-webdriver (4.18.1)
@@ -229,13 +220,12 @@ GEM
       rubocop (= 1.24.1)
       rubocop-performance (= 1.13.1)
     stringio (3.1.0)
-    strscan (3.0.1)
     swissmedic-diff (0.2.8)
       nokogiri
       rubyXL (>= 3.3.1)
       rubyzip
       spreadsheet
-    timeout (0.2.0)
+    timeout (0.4.1)
     travis-lint (2.0.0)
       json
     typeprof (0.21.2)

--- a/config.ru
+++ b/config.ru
@@ -7,12 +7,12 @@ lib_dir = File.expand_path(File.join(File.dirname(__FILE__), 'src'))
 $LOAD_PATH << lib_dir
 
 begin # with a rescue
-  require 'bigdecimal'
-  require 'date'
   require 'sbsm/logger'
   require 'rubyntlm'
   require 'net/ntlm'
   require "config"
+  require 'fileutils'
+  require 'date'
 
   server_uri = ODDB::SERVER_URI
   case APPNAME
@@ -36,21 +36,30 @@ begin # with a rescue
 
   load 'config.rb'
 
-  ODDB.config.log_pattern.gsub!('app', process.to_s)
-  SBSM.logger= ChronoLogger.new(ODDB.config.log_pattern)
+  log_dir = Dir.pwd + Date.today.strftime("/log/%Y/")
+  FileUtils.mkdir_p(log_dir)
+  $stdout.puts "log_dir now #{log_dir}"
+  SBSM.logger= Logger.new(log_dir + process.to_s + ".log", 'daily')
   # We want to redirect the standard error also to the logger
   # next line found via https://stackoverflow.com/questions/9637092/redirect-stderr-to-logger-instance
-  $stderr.reopen SBSM.logger.instance_variable_get(:@logdev).dev
-
+#  $stderr.reopen SBSM.logger.instance_variable_get(:@logdev).dev
+  SBSM.logger.progname = process.to_s;
   SBSM.logger.level = Logger::WARN
 
-  unless defined?(MiniTest) # do real startup
+  unless defined?(Minitest) # do real startup
     require 'util/oddbapp'
     require 'util/rack_interface'
-    require 'etc/db_connection'
-
-    File.open("/proc/#{Process.pid}/oom_adj", 'w') do |fh|
-      fh.puts "15"
+    begin
+      require 'etc/db_connection'
+    rescue LoadError
+      SBSM.logger.info("no file etc/db_connection found. Using defaults")
+    end
+    begin
+      File.open("/proc/#{Process.pid}/oom_score_adj", 'w') do |fh|
+        fh.puts "15"
+      end
+    rescue Errno::EACCES
+      SBSM.logger.info("Could not touch oom_score_adj")
     end
 
     trap("USR1") {
@@ -80,7 +89,7 @@ begin # with a rescue
     use Clogger, :logger=> $stdout, :reentrant => true
     use(Rack::Static, urls: ["/doc/"])
     use Rack::ContentLength
-    SBSM.warn "Starting Rack::Server with log_pattern #{ODDB.config.log_pattern}"
+    SBSM.warn "Starting Rack::Server with logging #{process.to_s}"
 
     $stdout.sync = true
     VERSION = `git rev-parse HEAD`
@@ -95,7 +104,7 @@ rescue => error
   exit(1)
 end
 
-unless defined?(MiniTest) # do real startup
+unless defined?(Minitest) # do real startup
   app = Rack::ShowExceptions.new(Rack::Lint.new(my_app))
   run app
 end

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,7 +20,7 @@ in
   env.ODDB_URL = "127.0.0.1:8012"; # for running the watir spec tests
 
   languages.ruby.enable = true;
-  languages.ruby.versionFile = ./.ruby-version;
+  languages.ruby.version = "3.3";
   services.postgres = {
     enable = true;
     package = pkgs-old.postgresql_10;

--- a/spec/domaintest_spec.rb
+++ b/spec/domaintest_spec.rb
@@ -60,6 +60,7 @@ DOMAINS= [
   DOMAINS.each do |domain|
     url = "https://#{domain}"
     it "should work with #{url}" do
+      pending "https://github.com/zdavatz/oddb.org/issues/267: Zur Zeit werden die nicht vermarktet, die werden nur weitergeleitet."
       unless is_link_valid?(url)
         fail "URL #{url} does not respond"
       end

--- a/test/test_util/config.rb
+++ b/test/test_util/config.rb
@@ -13,6 +13,7 @@ require 'stub/odba'
 require 'minitest/autorun'
 require 'flexmock/minitest'
 require 'util/config'
+require 'logger'
 
 module ODDB
   class TestConfig <Minitest::Test
@@ -72,13 +73,31 @@ module ODDB
     end
     def test_log_pattern_default_app
       eval("::APPNAME=  nil")
+      args1 = {:shift_age=>0, :shift_size=>1048576, :shift_period_suffix=>"%Y%m%d", :binmode=>false}
+      args2 = {:shift_age=>"daily", :shift_size=>1048576, :shift_period_suffix=>"%Y%m%d", :binmode=>false}
+      flexmock(Logger::LogDevice) do
+        |klass|
+        klass.should_receive(:new).once.with(
+           File.expand_path(File.join(File.dirname(__FILE__), '..', '..', "log/#{Date.today.year}/oddb.log")), args2)
+        klass.should_receive(:new).at_most.once.with(STDERR, args1) # may be called here or in test_log_pattern_with_appname
+      end
       load @config_ru
-      assert(ODDB.config.log_pattern.index('log/%Y/%m/%d/oddb_log'))
+      assert_equal('oddb', SBSM.logger.progname)
     end
     def test_log_pattern_with_appname
       eval("::APPNAME='crawler'")
+      args1 = {:shift_age=>0, :shift_size=>1048576, :shift_period_suffix=>"%Y%m%d", :binmode=>false}
+      args2 = {:shift_age=>"daily", :shift_size=>1048576, :shift_period_suffix=>"%Y%m%d", :binmode=>false}
+      flexmock(Logger::LogDevice) do
+        |klass|
+        klass.should_receive(:new).once.with(
+           File.expand_path(File.join(File.dirname(__FILE__), '..', '..', "log/#{Date.today.year}/crawler.log")), args2)
+        klass.should_receive(:new).at_most.once.with(STDERR, args1) # may be called here or in test_log_pattern_default_app
+      end
       load @config_ru
-      assert(ODDB.config.log_pattern.index('log/%Y/%m/%d/crawler_log'))
+      assert_equal('crawler', SBSM.logger.progname)
     end
   end
 end
+
+


### PR DESCRIPTION
Includes
* Changes to remove chrono_logger in config.ru
* Run github workflow with ruby 3.2 and ruby 3.3
* Devenv to use Ruby 3.3
* Update etc/barcode_to_text_info.rb

Tested:
* Unittests pass
* Watir spec tests has 2 errors less than with ruby 3.2 (not sure whether significant)
* The following jobs run locally without problems
  * import_daily
  * import_bsv
  * import_swissmedic
  
  Nota bene:
 After pulling, you must install ruby 3.3.0. Before calling `bundle install` you must set the include path for the used postgres version with something like `bundle config build.pg --with-pg-config=/usr/local/pg-10_1/bin/pg_config`